### PR TITLE
Replace basestring for python 3

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -12,6 +12,7 @@ if py_majversion == '2':
 else:
     from http.client import responses as HTTP_CODES
     from urllib.parse import urlparse
+    basestring = str
 
 DOWNLOAD_CHUNK_SIZE_BYTES = 1 * 1024 * 1024
 


### PR DESCRIPTION
Basestring has been removed in Python 3 as unicode is used universally.
More elegant solution would use the six module for this, see: https://pythonhosted.org/six/#six.string_types
